### PR TITLE
Added hierarchy for derive spec, added support for unknown sizes, added async stream based iterator.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/austinleroy/ebml-iterable"
 [dependencies]
 ebml-iterable-specification = { version = "=0.2.0", path = "specification" }
 ebml-iterable-specification-derive = { version = "=0.2.0", path = "specification-derive", optional = true }
+futures = "0.3.21"
 
 [features]
 derive-spec = ["ebml-iterable-specification-derive"]

--- a/specification-derive/Cargo.toml
+++ b/specification-derive/Cargo.toml
@@ -16,3 +16,4 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 ebml-iterable-specification = { version = "=0.2.0", path = "../specification" }
+itertools = "0.10.3"

--- a/specification-derive/src/ast.rs
+++ b/specification-derive/src/ast.rs
@@ -47,7 +47,7 @@ impl<'a> Variant<'a> {
         let mut id_attr: Option<(u64, Attribute<'a>)> = None;
         let mut data_type_attr: Option<(TagDataType, Path, Attribute<'a>)> = None;
         let mut parent_attr: Option<(Ident, Attribute<'a>)> = None;
-    
+
         for attr in &node.attrs {
             if attr.path.is_ident("id") {
                 if id_attr.is_some() {

--- a/specification-derive/src/ast.rs
+++ b/specification-derive/src/ast.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::fmt::format;
 use proc_macro2::TokenStream;
 use syn::{ItemEnum, Error, Generics, Ident, Result, LitInt, Path};
 

--- a/specification-derive/src/easy_ebml.rs
+++ b/specification-derive/src/easy_ebml.rs
@@ -1,0 +1,112 @@
+use proc_macro2::TokenStream;
+use syn::{Attribute, AttrStyle, Ident, LitInt, parse::Parse, Path, Token, Variant, Visibility};
+use syn::parse::{ParseBuffer, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::Result;
+use syn::Error;
+use quote::{quote};
+use syn::spanned::Spanned;
+
+pub struct EasyEBML {
+    attrs: Vec<Attribute>,
+    visibility: Visibility,
+    ident: Ident,
+    variants: Punctuated<EasyEBMLVariant, Token![,]>
+}
+
+
+impl Parse for EasyEBML {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let visibility: Visibility = input.parse()?;
+        input.parse::<Token![enum]>()?;
+        let ident = input.parse::<Ident>()?;
+        let content: ParseBuffer;
+        syn::braced!(content in input);
+        let variants = content.parse_terminated(EasyEBMLVariant::parse)?;
+        Ok(Self {
+            attrs,
+            visibility,
+            ident,
+            variants
+        })
+    }
+}
+
+impl EasyEBML {
+
+    pub fn implement(self) -> Result<TokenStream> {
+        let EasyEBML { attrs, visibility, ident, variants } = self;
+
+        let variants: Vec<_> = variants.into_iter().map(EasyEBMLVariant::into_variant).collect::<Result<_>>()?;
+
+        Ok(quote!(
+            #[ebml_iterable::specs::ebml_specification]
+            #(#attrs)*
+            #visibility enum #ident {
+                #(#variants),*
+            }
+        ))
+    }
+}
+
+pub struct EasyEBMLVariant {
+    path: Punctuated<Ident, Token![/]>,
+    ty: Ident,
+    id: LitInt
+}
+
+impl EasyEBMLVariant {
+    pub fn into_variant(self) -> Result<Variant> {
+        let EasyEBMLVariant { mut path, ty, id } = self;
+        let ident = path.pop().ok_or_else(|| Error::new(path.span(), "easy_ebml enum variant must be at least: `Name: Type = id`"))?.into_value();
+        let mut attrs = vec![];
+        attrs.push(Attribute {
+            pound_token: Default::default(),
+            style: AttrStyle::Outer,
+            bracket_token: Default::default(),
+            path: Ident::new("id", proc_macro2::Span::call_site()).into(),
+            tokens: quote!((#id))
+        });
+        attrs.push(Attribute {
+            pound_token: Default::default(),
+            style: AttrStyle::Outer,
+            bracket_token: Default::default(),
+            path: Ident::new("data_type", proc_macro2::Span::call_site()).into(),
+            tokens: quote!((TagDataType::#ty))
+        });
+
+        if let Some(it) = path.pop() {
+            let it = it.into_value();
+            attrs.push(Attribute {
+                pound_token: Default::default(),
+                style: AttrStyle::Outer,
+                bracket_token: Default::default(),
+                path: Ident::new("parent", proc_macro2::Span::call_site()).into(),
+                tokens: quote!((#it))
+            });
+        }
+
+        Ok(Variant {
+            attrs,
+            ident,
+            fields: syn::Fields::Unit,
+            discriminant: None
+        })
+    }
+}
+
+impl Parse for EasyEBMLVariant {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let path = Punctuated::parse_separated_nonempty(input)?;
+        input.parse::<Token![:]>()?;
+        let ty: Ident = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let id: LitInt = input.parse()?;
+        Ok(Self {
+            path,
+            ty,
+            id
+        })
+    }
+}

--- a/specification-derive/src/easy_ebml.rs
+++ b/specification-derive/src/easy_ebml.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use syn::{Attribute, AttrStyle, Ident, LitInt, parse::Parse, Path, Token, Variant, Visibility};
+use syn::{Attribute, AttrStyle, Ident, LitInt, parse::Parse, Token, Variant, Visibility};
 use syn::parse::{ParseBuffer, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::Result;

--- a/specification-derive/src/lib.rs
+++ b/specification-derive/src/lib.rs
@@ -2,19 +2,21 @@ extern crate proc_macro;
 
 mod ast;
 mod attr;
+mod easy_ebml;
 
 use proc_macro::TokenStream;
 use syn::{ItemEnum, Error};
+use crate::easy_ebml::EasyEBML;
 
 ///
 /// Attribute that derives implementations of EbmlSpecification and EbmlTag for an enum.
-/// 
+///
 /// This macro is intended to make implementing the traits in ebml-iterable-specification easier to manage.  Rather than requiring handwritten implementations for `EbmlSpecification` and `EbmlTag` methods, this macro understands attributes assigned to enum members and generates an implementation accordingly.
-/// 
+///
 /// When deriving `EbmlSpecification` for an enum, the following attributes are required for each variant:
 ///   * __#[id(`u64`)]__ - This attribute specifies the "id" of the tag. e.g. `0x1a45dfa3`
 ///   * __#[data_type(`TagDataType`)]__ - This attribute specifies the type of data contained in the tag. e.g. `TagDataType::UnsignedInt`
-/// 
+///
 /// # Note
 ///
 /// This attribute modifies the variants in the enumeration by adding fields to them.  It also will add a `RawTag(u64, Vec<u8>)` variant to the enumeration.
@@ -32,4 +34,24 @@ pub fn ebml_specification(_args: TokenStream, input: TokenStream) -> TokenStream
     attr::impl_ebml_specification(&mut input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
+}
+
+
+#[proc_macro]
+pub fn easy_ebml(input: TokenStream) -> TokenStream {
+    let input = match syn::parse::<EasyEBML>(input) {
+        Ok(syntax_tree) => syntax_tree,
+        Err(err) => {
+            return TokenStream::from(Error::new(err.span(), "easy_ebml! {} content must be of format: enum Name {\
+                Root: Type = id,\
+                Path/Of/Component: Type = id,\
+                // example\
+                Crc32: Binary = 0xbf,\
+                Ebml: Master = 0x1a45dfa3,\
+                Ebml/EbmlVersion: UnsignedInt = 0x4286,\
+            }").to_compile_error())
+        },
+    };
+
+    input.implement().unwrap_or_else(|err| err.to_compile_error()).into()
 }

--- a/specification/src/empty_spec.rs
+++ b/specification/src/empty_spec.rs
@@ -98,4 +98,10 @@ impl EbmlTag<EmptySpec> for EmptySpec {
             None => None
         }
     }
+
+    fn is_child(&self, id: u64) -> bool {
+        // This assumes we know there are no unknown or unexpected elements
+        // To correctly be implemented, this should know all parent, root and sibling elements and return false if it is one of them, because spec requires them to be the only stop conditions.
+        self.children.iter().any(|it|it.clone().get_children().iter().any(|it|it.id == id))
+    }
 }

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -101,12 +101,6 @@ pub trait EbmlSpecification<T: EbmlSpecification<T> + EbmlTag<T> + Clone> {
     ///
     fn get_raw_tag(id: u64, data: &[u8]) -> T;
 
-    ///
-    /// Tests if [id] is a root element
-    ///
-    /// Used to determine if Unknown size blocks should end
-    ///
-    fn is_root(id: u64) -> bool;
 }
 
 ///
@@ -170,16 +164,14 @@ pub trait EbmlTag<T: Clone> {
     ///
     /// Tests if [id] is a child of self
     ///
-    /// Used to determine if Unknown size blocks should end
+    /// Default is [true]
+    /// Unknown or unexpected elements are children. Global elements are children.
+    ///
+    /// Used to determine if Unknown size blocks should end. If [is_child] returns false, the Unknown size block ends.
+    ///
+    /// [`Spec`](https://github.com/ietf-wg-cellar/ebml-specification/blob/master/specification.markdown#unknown-data-size) does not explicitly state what to do in case of an unexpected element, so we assume it will be handled like a child element since it is not one of the end conditions.
     ///
     fn is_child(&self, id: u64) -> bool;
-
-    ///
-    /// Tests if [id] is a parent of self
-    ///
-    /// Used to determine if Unknown size blocks should end
-    ///
-    fn is_parent(&self, id: u64) -> bool;
 }
 
 ///

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -165,6 +165,7 @@ pub trait EbmlTag<T: Clone> {
     /// Tests if [id] is a child of self
     ///
     /// Default is [true]
+    ///
     /// Unknown or unexpected elements are children. Global elements are children.
     ///
     /// Used to determine if Unknown size blocks should end. If [is_child] returns false, the Unknown size block ends.

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -1,5 +1,5 @@
 //! This crate provides a core ebml specification that is used by the ebml-iterable crate.
-//! 
+//!
 //! The related ebml-iterable-specification-derive crate can be used to simplify implementation of this spec.
 //!
 
@@ -10,11 +10,11 @@ pub mod empty_spec;
 
 ///
 /// Different data types defined in the EBML specification.
-/// 
-/// # Notes 
+///
+/// # Notes
 ///
 /// This library made a concious decision to not work with "Date" elements from EBML due to lack of built-in support for dates in Rust. Specification implementations should treat Date elements as Binary so that consumers have the option of parsing the unaltered data using their library of choice, if needed.
-/// 
+///
 
 // Possible future feature flag to enable Date functionality by having `chrono` as an optional dependency?
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -29,7 +29,7 @@ pub enum TagDataType {
 
 ///
 /// This trait, along with [`EbmlTag`], should be implemented to define a specification so that EBML can be parsed correctly.  Typically implemented on an Enum of tag variants.
-/// 
+///
 /// Any specification using EBML can take advantage of this library to parse or write binary data.  As stated in the docs, [`TagWriter`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagWriter.html) needs nothing special if you stick with the `write_raw` method, but [`TagIterator`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagIterator.html) requires a struct implementing this trait.  Custom specification implementations can refer to [webm-iterable](https://crates.io/crates/webm_iterable) as an example.
 ///
 /// This trait and [`EbmlTag`] are typically implemented simultaneously.  They are separate traits as they have primarily different uses - [`EbmlSpecification`] should be brought into scope when dealing with the specification as a whole, whereas [`EbmlTag`] should be brought into scope when dealing with specific tags.
@@ -42,7 +42,7 @@ pub trait EbmlSpecification<T: EbmlSpecification<T> + EbmlTag<T> + Clone> {
     /// This function *must* return [`TagDataType::Binary`] if the input id is not in the specification.  Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_tag_data_type(id: u64) -> TagDataType;
-    
+
     ///
     /// Gets the id of a specific tag variant.
     ///
@@ -51,60 +51,67 @@ pub trait EbmlSpecification<T: EbmlSpecification<T> + EbmlTag<T> + Clone> {
     fn get_tag_id(item: &T) -> u64 {
         item.get_id()
     }
-    
+
     ///
-    /// Creates an unsigned integer type tag from the spec.  
+    /// Creates an unsigned integer type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::UnsignedInt`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_unsigned_int_tag(id: u64, data: u64) -> Option<T>;
-    
+
     ///
-    /// Creates a signed integer type tag from the spec.  
+    /// Creates a signed integer type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Integer`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_signed_int_tag(id: u64, data: i64) -> Option<T>;
-    
+
     ///
-    /// Creates a utf8 type tag from the spec.  
+    /// Creates a utf8 type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Utf8`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_utf8_tag(id: u64, data: String) -> Option<T>;
-    
+
     ///
-    /// Creates a binary type tag from the spec.  
+    /// Creates a binary type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Binary`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_binary_tag(id: u64, data: &[u8]) -> Option<T>;
-    
+
     ///
-    /// Creates a float type tag from the spec.  
+    /// Creates a float type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Float`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_float_tag(id: u64, data: f64) -> Option<T>;
-    
+
     ///
-    /// Creates a master type tag from the spec.  
+    /// Creates a master type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Master`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_master_tag(id: u64, data: Master<T>) -> Option<T>;
 
     ///
-    /// Creates a tag that does not conform to the spec. 
+    /// Creates a tag that does not conform to the spec.
     ///
     /// This function should return a "RawTag" variant that contains the tag id and tag data.  Tag data should only be retrievable as binary data. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_raw_tag(id: u64, data: &[u8]) -> T;
+
+    ///
+    /// Tests if [id] is a root element
+    ///
+    /// Used to determine if Unknown size blocks should end
+    ///
+    fn is_root(id: u64) -> bool;
 }
 
 ///
 /// This trait, along with [`EbmlSpecification`], should be implemented to define a specification so that EBML can be parsed correctly.  Typically implemented on an Enum of tag variants.
-/// 
+///
 /// Any specification using EBML can take advantage of this library to parse or write binary data.  As stated in the docs, [`TagWriter`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagWriter.html) needs nothing special if you stick with the `write_raw` method, but [`TagIterator`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagIterator.html) requires a struct implementing this trait.  Custom specification implementations can refer to [webm-iterable](https://crates.io/crates/webm_iterable) as an example.
 ///
 /// This trait and [`EbmlSpecification`] are typically implemented simultaneously.  They are separate traits as they have primarily different uses - [`EbmlSpecification`] should be brought into scope when dealing with the specification as a whole, whereas [`EbmlTag`] should be brought into scope when dealing with specific tags.
@@ -159,6 +166,20 @@ pub trait EbmlTag<T: Clone> {
     /// This function *must* return `None` if the associated data type of `self` is not [`TagDataType::Master`].  Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn as_master(&self) -> Option<&Master<T>>;
+
+    ///
+    /// Tests if [id] is a child of self
+    ///
+    /// Used to determine if Unknown size blocks should end
+    ///
+    fn is_child(&self, id: u64) -> bool;
+
+    ///
+    /// Tests if [id] is a parent of self
+    ///
+    /// Used to determine if Unknown size blocks should end
+    ///
+    fn is_parent(&self, id: u64) -> bool;
 }
 
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,43 +1,43 @@
 //! This crate provides an iterator and a serializer for [EBML][EBML] files.  Its primary goal is to provide typed iteration and serialization as lightly and quickly as possible.
-//! 
+//!
 //! [EBML][EBML] stands for Extensible Binary Meta-Language and is somewhat of a
 //! binary version of XML. It's used for container formats like [WebM][webm] or
 //! [MKV][mkv].
-//! 
+//!
 //! # Important - Specifications
 //! The iterator contained in this crate is spec-agnostic and requires a specification implementing the [`specs::EbmlSpecification`] and [`specs::EbmlTag`] traits to read files.  Typically, you would only use this crate to implement a custom specification - most often you would prefer a crate providing an existing specification, like [webm-iterable][webm-iterable].
-//! 
-//! Implementing custom specifications can be made less painful by enabling the `"derive-spec"` feature flag in this crate and using the [`#[ebml_specification]`](https://docs.rs/ebml-iterable-specification-derive/latest/ebml_iterable_specification_derive/attr.ebml_specification.html) macro.
-//! 
+//!
+//! Implementing custom specifications can be made less painful and safer by enabling the `"derive-spec"` feature flag in this crate and using the [`#[ebml_specification]`](https://docs.rs/ebml-iterable-specification-derive/latest/ebml_iterable_specification_derive/attr.ebml_specification.html) macro.
+//!
 //! # Features
-//! 
+//!
 //! There is currently only one optional feature in this crate, but that may change over time as needs arise.
-//! 
+//!
 //! * **derive-spec** -
 //!     When enabled, this provides the [`#[ebml_specification]`](https://docs.rs/ebml-iterable-specification-derive/latest/ebml_iterable_specification_derive/attr.ebml_specification.html) attribute macro to simplify implementation of the [`EbmlSpecification`][`specs::EbmlSpecification`] and [`EbmlTag`][`specs::EbmlTag`] traits.  This introduces dependencies on [`syn`](https://crates.io/crates/syn), [`quote`](https://crates.io/crates/quote), and [`proc-macro2`](https://crates.io/crates/proc-macro2), so expect compile times to increase a little.
-//! 
-//! # Known Limitations
-//! This library was not built to work with an "Unknown Data Size" as defined in [RFC8794][rfc8794]. As such, it likely will not support streaming applications and will only work on complete datasets.
-//! 
+//!
 //! [EBML]: http://ebml.sourceforge.net/
 //! [webm]: https://www.webmproject.org/
 //! [mkv]: http://www.matroska.org/technical/specs/index.html
 //! [rfc8794]: https://datatracker.ietf.org/doc/rfc8794/
 //! [webm-iterable]: https://crates.io/crates/webm_iterable
-//! 
+//!
 
 mod errors;
 mod tag_iterator;
+mod tag_iterator_async;
 mod tag_writer;
 pub mod tools;
 pub mod specs;
+mod tag_iterator_util;
 
 pub use self::tag_iterator::TagIterator;
+pub use self::tag_iterator_async::TagIteratorAsync;
 pub use self::tag_writer::TagWriter;
 
 pub mod error {
 
-    //! 
+    //!
     //! Potential errors that can occur when reading or writing EBML data.
     //!
     pub use super::errors::tag_iterator::TagIteratorError;
@@ -46,5 +46,5 @@ pub mod error {
     ///
     /// Error details that may be included in some thrown errors
     ///
-    pub use super::errors::tool::ToolError; 
+    pub use super::errors::tool::ToolError;
 }

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -1,11 +1,13 @@
 //!
 //! Provides the EBML specification types.
-//! 
+//!
 //! Typically won't be used unless you are implementing a custom specification that uses EBML.  You can enable the `"derive-spec"` feature to obtain a macro to make implementation easier.
-//! 
+//!
 
 #[cfg(feature = "derive-spec")]
 pub use ebml_iterable_specification_derive::ebml_specification;
+#[cfg(feature = "derive-spec")]
+pub use ebml_iterable_specification_derive::easy_ebml;
 
 pub use ebml_iterable_specification::EbmlSpecification as EbmlSpecification;
 pub use ebml_iterable_specification::EbmlTag as EbmlTag;

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -188,7 +188,7 @@ impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
         Some(self.read_tag().await)
     }
 
-    pub async fn into_stream(self) -> impl Stream<Item=Result<TSpec, TagIteratorError>> {
+    pub fn into_stream(self) -> impl Stream<Item=Result<TSpec, TagIteratorError>> {
         futures::stream::unfold(self, |mut read| async {
             let next = read.next().await;
             next.map(move |it| (it, read))

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -103,7 +103,7 @@ impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
             let size = if let Known(size) = size {
                 size
             } else {
-                unreachable!("Unknown size for primitive not allowed")
+                return Err(TagIteratorError::CorruptedFileData("Unknown size for primitive not allowed".into()));
             };
             let raw_data = self.read_tag_data(size).await?;
             match spec_tag_type {

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -1,0 +1,163 @@
+use std::iter::repeat;
+use std::mem;
+use ebml_iterable_specification::{EbmlSpecification, EbmlTag, Master, TagDataType};
+use futures::{AsyncRead, AsyncReadExt, Stream};
+use crate::error::{TagIteratorError, ToolError};
+use crate::tag_iterator_util::{EBMLSize, ProcessingTag};
+use crate::tag_iterator_util::EBMLSize::Known;
+use crate::tag_iterator_util::ProcessingTag::{EndTag, NextTag};
+use crate::tools;
+
+pub struct TagIteratorAsync<R: AsyncRead + Unpin, TSpec>
+    where
+        TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
+{
+    read: R,
+    buf: Vec<u8>,
+    offset: usize,
+    tag_stack: Vec<ProcessingTag<TSpec>>
+}
+
+impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
+    where
+        TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
+{
+
+    fn new(read: R) -> Self {
+        Self {
+            read,
+            buf: Default::default(),
+            offset: 0,
+            tag_stack: Default::default()
+        }
+    }
+
+    fn current_offset(&self) -> usize {
+        self.offset
+    }
+
+    fn advance(&mut self, length: usize) {
+        self.offset += length;
+        self.buf.drain(0..length);
+    }
+
+    fn advance_get(&mut self, length: usize) -> Vec<u8> {
+        self.offset += length;
+        let upper = self.buf.split_off(length);
+        mem::replace(&mut self.buf, upper)
+    }
+
+    async fn ensure_data_read(&mut self, len: usize) -> Result<bool, TagIteratorError> {
+        let size = self.buf.len();
+        if size < len {
+            let remaining = len - size;
+            self.buf.extend(repeat(0).take(remaining));
+            self.read.read_exact(&mut self.buf[size..]).await.map_err(|source| TagIteratorError::ReadError { source })?
+        }
+        Ok(true)
+    }
+
+    async fn read_tag_id(&mut self) -> Result<u64, TagIteratorError> {
+        self.ensure_data_read(8).await?;
+        match tools::read_vint(&self.buf).map_err(|e| TagIteratorError::CorruptedFileData(e.to_string()))? {
+            Some((value, length)) => {
+                self.advance(length);
+                Ok(value + (1 << (7 * length)))
+            },
+            None => Err(TagIteratorError::CorruptedFileData(String::from("Expected tag id, but reached end of source."))),
+        }
+    }
+
+    async fn read_tag_size(&mut self) -> Result<EBMLSize, TagIteratorError> {
+        self.ensure_data_read(8).await?;
+        match tools::read_vint(&self.buf).map_err(|e| TagIteratorError::CorruptedFileData(e.to_string()))? {
+            Some((value, length)) => {
+                self.advance(length);
+                Ok(value.into())
+            },
+            None => Err(TagIteratorError::CorruptedFileData(String::from("Expected tag size, but reached end of source."))),
+        }
+    }
+
+    async fn read_tag_data(&mut self, size: usize) -> Result<Vec<u8>, TagIteratorError> {
+        if !self.ensure_data_read(size).await? {
+            return Err(TagIteratorError::CorruptedFileData(String::from("reached end of file but expecting more data")));
+        }
+        Ok(self.advance_get(size))
+    }
+
+    async fn read_tag(&mut self) -> Result<TSpec, TagIteratorError> {
+        let tag_id = self.read_tag_id().await?;
+        let spec_tag_type = TSpec::get_tag_data_type(tag_id);
+        let size = self.read_tag_size().await?;
+
+        let is_master = matches!(spec_tag_type, TagDataType::Master);
+        let tag = if is_master {
+            self.tag_stack.push(EndTag {
+                tag: TSpec::get_master_tag(tag_id, Master::End).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was master, but could not get tag!", tag_id)),
+                size,
+                start: self.current_offset(),
+            });
+            TSpec::get_master_tag(tag_id, Master::Start).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was master, but could not get tag!", tag_id))
+        } else {
+            let size = if let Known(size) = size {
+                size
+            } else {
+                unreachable!("Unknown size for primitive not allowed")
+            };
+            let raw_data = self.read_tag_data(size).await?;
+            match spec_tag_type {
+                TagDataType::Master => { unreachable!("Master should have been handled before querying data") },
+                TagDataType::UnsignedInt => {
+                    let val = tools::arr_to_u64(&raw_data).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: e })?;
+                    TSpec::get_unsigned_int_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was unsigned int, but could not get tag!", tag_id))
+                },
+                TagDataType::Integer => {
+                    let val = tools::arr_to_i64(&raw_data).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: e })?;
+                    TSpec::get_signed_int_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was integer, but could not get tag!", tag_id))
+                },
+                TagDataType::Utf8 => {
+                    let val = String::from_utf8(raw_data.to_vec()).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: ToolError::FromUtf8Error(raw_data, e) })?;
+                    TSpec::get_utf8_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was utf8, but could not get tag!", tag_id))
+                },
+                TagDataType::Binary => {
+                    TSpec::get_binary_tag(tag_id, &raw_data).unwrap_or_else(|| TSpec::get_raw_tag(tag_id, &raw_data))
+                },
+                TagDataType::Float => {
+                    let val = tools::arr_to_f64(&raw_data).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: e })?;
+                    TSpec::get_float_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was float, but could not get tag!", tag_id))
+                },
+            }
+        };
+
+        if self.tag_stack.last().map(|it| tag.is_child(it.get_id())).unwrap_or(true) {
+            Ok(tag)
+        } else {
+            Ok(mem::replace(self.tag_stack.last_mut().unwrap(), NextTag { tag }).into_inner())
+        }
+    }
+
+    pub async fn next(&mut self) -> Option<Result<TSpec, TagIteratorError>> {
+        if let Some(tag) = self.tag_stack.pop() {
+            match tag {
+                EndTag { size, start, tag } => {
+                    if let Known(size) = size {
+                        if self.current_offset() >= start + size {
+                            return Some(Ok(tag));
+                        }
+                    }
+                    self.tag_stack.push(EndTag { size, start, tag });
+                },
+                NextTag { tag } => return Some(Ok(tag))
+            }
+        }
+        Some(self.read_tag().await)
+    }
+
+    pub async fn into_stream(self) -> impl Stream<Item=Result<TSpec, TagIteratorError>> {
+        futures::stream::unfold(self, |mut read| async {
+            let next = read.next().await;
+            next.map(move |it| (it, read))
+        })
+    }
+}

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -23,7 +23,7 @@ impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
         TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
 {
 
-    fn new(read: R) -> Self {
+    pub fn new(read: R) -> Self {
         Self {
             read,
             buf: Default::default(),

--- a/src/tag_iterator_util.rs
+++ b/src/tag_iterator_util.rs
@@ -1,0 +1,64 @@
+use ebml_iterable_specification::{EbmlSpecification, EbmlTag};
+use std::convert::TryInto;
+use crate::tag_iterator_util::EBMLSize::{Known, Unknown};
+use crate::tag_iterator_util::ProcessingTag::{EndTag, NextTag};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum EBMLSize {
+    Known(usize),
+    Unknown
+}
+
+impl From<u64> for EBMLSize {
+    fn from(size: u64) -> Self {
+        Self::new(size)
+    }
+}
+
+impl EBMLSize {
+
+    pub fn new(size: u64) -> Self {
+        const UNKNOWN: u64 = u64::MAX >> 8;
+        if size == UNKNOWN {
+            return Unknown
+        } else {
+            match size.try_into() {
+                Ok(value) => Known(value),
+                Err(_) => Unknown
+            }
+        }
+    }
+
+}
+
+pub enum ProcessingTag<TSpec>
+    where TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
+{
+    EndTag {
+        tag: TSpec,
+        size: EBMLSize,
+        start: usize,
+    },
+    NextTag {
+        tag: TSpec,
+    }
+}
+
+impl<TSpec> ProcessingTag<TSpec> where TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone {
+
+    pub fn get_id(&self) -> u64 {
+        match self {
+            EndTag { tag,.. } => tag.get_id(),
+            NextTag { tag } => tag.get_id()
+        }
+    }
+
+    pub fn into_inner(self) -> TSpec {
+        match self {
+            EndTag { tag,.. } => tag,
+            NextTag { tag } => tag
+        }
+    }
+}
+
+pub const DEFAULT_BUFFER_LEN: usize = 1024 * 64;

--- a/src/tag_iterator_util.rs
+++ b/src/tag_iterator_util.rs
@@ -59,6 +59,13 @@ impl<TSpec> ProcessingTag<TSpec> where TSpec: EbmlSpecification<TSpec> + EbmlTag
             NextTag { tag } => tag
         }
     }
+
+    pub fn inner(&self) -> &TSpec {
+        match self {
+            EndTag { tag,.. } => tag,
+            NextTag { tag } => tag
+        }
+    }
 }
 
 pub const DEFAULT_BUFFER_LEN: usize = 1024 * 64;

--- a/tests/derive_spec_compile_with_hierarchy.rs
+++ b/tests/derive_spec_compile_with_hierarchy.rs
@@ -1,0 +1,51 @@
+#[cfg(feature = "derive-spec")]
+pub mod derive_spec_compile {
+    use ebml_iterable::specs::{ebml_specification, TagDataType, Master, EbmlSpecification};
+    
+    #[ebml_specification]
+    #[derive(Clone, Debug, PartialEq)]
+    pub enum Trial {
+        #[id(0x01)]
+        #[data_type(TagDataType::Master)]
+        Root,
+
+        #[id(0x02)]
+        #[data_type(TagDataType::Master)]
+        #[parent(Root)]
+        Parent,
+
+        #[id(0x100)]
+        #[data_type(TagDataType::UnsignedInt)]
+        #[parent(Parent)]
+        Count,
+
+        #[id(0x200)]
+        #[data_type(TagDataType::Binary)]
+        #[parent(Parent)]
+        Data,
+
+        #[id(0x201)]
+        #[data_type(TagDataType::Utf8)]
+        #[parent(Parent)]
+        Name,
+
+        #[id(0x102)]
+        #[data_type(TagDataType::Float)]
+        #[parent(Parent)]
+        Amount,
+
+        #[id(0x101)]
+        #[data_type(TagDataType::Integer)]
+        #[parent(Parent)]
+        Id,  
+    }
+
+    #[test]
+    pub fn compile_worked() {
+        let data_type = Trial::get_tag_data_type(0x01);
+        assert_eq!(TagDataType::Master, data_type);
+        
+        let tag = Trial::get_master_tag(0x01, Master::Start).unwrap();
+        assert_eq!(Trial::Root(Master::Start), tag);
+    }
+}


### PR DESCRIPTION
- Added hierarchy for derive spec
- Changed trait with new function is_child to test for unsized stream end.
- refactored `tag_iterator` to support unknown sizes (incompatible with buffering, it would have required to rewrite the thinge entirely)
- added `tag_iterator_async` based on `AsyncRead` that can be made into a `futures::Stream`, or just iterated normally using `next().await`

This is made to contribute to the webm-iterable crate that i use.

A few tests are missing, and a bit of documentation would be nice. 
