### PR TITLE
Unknown size updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebml-iterable"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Austin Blake <austinl3roy@gmail.com>"]
 edition = "2018"
 description = "This crate provides an iterator over EBML encoded data.  The items provided by the iterator are Tags as defined in EBML.  The iterator is spec-agnostic and requires a specification implementing specific traits to read files.  Typically, you would only use this crate to implement a custom specification - most often you would prefer a crate providing an existing specification, like `webm-iterable`."
@@ -14,8 +14,8 @@ repository = "https://github.com/austinleroy/ebml-iterable"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ebml-iterable-specification = { version = "=0.2.0", path = "specification" }
-ebml-iterable-specification-derive = { version = "=0.2.0", path = "specification-derive", optional = true }
+ebml-iterable-specification = { version = "=0.3.0", path = "specification" }
+ebml-iterable-specification-derive = { version = "=0.3.0", path = "specification-derive", optional = true }
 futures = "0.3.21"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ repository = "https://github.com/austinleroy/ebml-iterable"
 [dependencies]
 ebml-iterable-specification = { version = "=0.2.0", path = "specification" }
 ebml-iterable-specification-derive = { version = "=0.2.0", path = "specification-derive", optional = true }
+futures = "0.3.21"
 
 [features]
 derive-spec = ["ebml-iterable-specification-derive"]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ binary version of XML. It's used for container formats like [WebM][webm] or
 
 > IMPORTANT: The iterator contained in this crate is spec-agnostic and requires a specification implementing the `EbmlSpecification` and `EbmlTag` traits to read files.  Typically, you would only use this crate to implement a custom specification - most often you would prefer a crate providing an existing specification, like [webm-iterable][webm-iterable].
 
-> KNOWN LIMITATION: This library was not built to work with an "Unknown Data Size" as defined in [RFC8794][rfc8794]. As such, it likely will not support streaming applications and will only work on complete datasets.
-
 ```Cargo.toml
 [dependencies]
-ebml-iterable = "0.3.2"
+ebml-iterable = "0.4.0"
 ```
 
 # Usage
@@ -66,7 +64,7 @@ There is currently only one optional feature in this crate, but that may change 
 
 # State of this project
 
-Parsing and writing complete files should both work.  Streaming isn't supported yet, but may be an option in the future. If something is broken, please create [an issue][new-issue].
+Parsing and writing complete files should both work.  Streaming (using tags of unknown size) should now also be supported, as of version 0.4.0. If something is broken, please create [an issue][new-issue].
 
 Any additional feature requests can also be submitted as [an issue][new-issue].
 

--- a/specification-derive/Cargo.toml
+++ b/specification-derive/Cargo.toml
@@ -16,3 +16,4 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 ebml-iterable-specification = { version = "=0.2.0", path = "../specification" }
+itertools = "0.10.3"

--- a/specification-derive/Cargo.toml
+++ b/specification-derive/Cargo.toml
@@ -16,4 +16,3 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 ebml-iterable-specification = { version = "=0.2.0", path = "../specification" }
-itertools = "0.10.3"

--- a/specification-derive/Cargo.toml
+++ b/specification-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebml-iterable-specification-derive"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Austin Blake <austinl3roy@gmail.com>"]
 edition = "2018"
 description = "Provides macros for implementing `EbmlSpecification` for the `ebml-iterable` crate."
@@ -15,4 +15,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
-ebml-iterable-specification = { version = "=0.2.0", path = "../specification" }
+ebml-iterable-specification = { version = "=0.3.0", path = "../specification" }

--- a/specification-derive/src/ast.rs
+++ b/specification-derive/src/ast.rs
@@ -56,7 +56,7 @@ impl<'a> Variant<'a> {
                 }
                 let val = attr.parse_args::<LitInt>()?.base10_parse::<u64>()?;
                 id_attr = Some((val, Attribute {
-                    original: &attr,
+                    original: attr,
                     tokens: &attr.tokens,
                 }));
             } else if attr.path.is_ident("data_type") {
@@ -86,7 +86,7 @@ impl<'a> Variant<'a> {
                     return Err(Error::new_spanned(val, format!("unrecognized `ebml_iterable::TagDataType` value: {}", data_type_name)));
                 };
                 data_type_attr = Some((data_type_val, val, Attribute {
-                    original: &attr,
+                    original: attr,
                     tokens: &attr.tokens,
                 }));
             } else if attr.path.is_ident("parent") {
@@ -100,7 +100,7 @@ impl<'a> Variant<'a> {
                 // take from set to keep proper span in case of errors
                 let def = variant_names.get(&ident).ok_or_else(|| Error::new(ident.span(), format!("{} must be Spec variant", attr.to_token_stream())))?.clone();
                 parent_attr = Some((def, Attribute {
-                    original: &attr,
+                    original: attr,
                     tokens: &attr.tokens,
                 }))
             }

--- a/specification-derive/src/ast.rs
+++ b/specification-derive/src/ast.rs
@@ -47,7 +47,7 @@ impl<'a> Variant<'a> {
         let mut id_attr: Option<(u64, Attribute<'a>)> = None;
         let mut data_type_attr: Option<(TagDataType, Path, Attribute<'a>)> = None;
         let mut parent_attr: Option<(Ident, Attribute<'a>)> = None;
-    
+
         for attr in &node.attrs {
             if attr.path.is_ident("id") {
                 if id_attr.is_some() {

--- a/specification-derive/src/ast.rs
+++ b/specification-derive/src/ast.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::fmt::format;
 use proc_macro2::TokenStream;
 use syn::{ItemEnum, Error, Generics, Ident, Result, LitInt, Path};
 

--- a/specification-derive/src/easy_ebml.rs
+++ b/specification-derive/src/easy_ebml.rs
@@ -1,0 +1,112 @@
+use proc_macro2::TokenStream;
+use syn::{Attribute, AttrStyle, Ident, LitInt, parse::Parse, Path, Token, Variant, Visibility};
+use syn::parse::{ParseBuffer, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::Result;
+use syn::Error;
+use quote::{quote};
+use syn::spanned::Spanned;
+
+pub struct EasyEBML {
+    attrs: Vec<Attribute>,
+    visibility: Visibility,
+    ident: Ident,
+    variants: Punctuated<EasyEBMLVariant, Token![,]>
+}
+
+
+impl Parse for EasyEBML {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let visibility: Visibility = input.parse()?;
+        input.parse::<Token![enum]>()?;
+        let ident = input.parse::<Ident>()?;
+        let content: ParseBuffer;
+        syn::braced!(content in input);
+        let variants = content.parse_terminated(EasyEBMLVariant::parse)?;
+        Ok(Self {
+            attrs,
+            visibility,
+            ident,
+            variants
+        })
+    }
+}
+
+impl EasyEBML {
+
+    pub fn implement(self) -> Result<TokenStream> {
+        let EasyEBML { attrs, visibility, ident, variants } = self;
+
+        let variants: Vec<_> = variants.into_iter().map(EasyEBMLVariant::into_variant).collect::<Result<_>>()?;
+
+        Ok(quote!(
+            #[ebml_iterable::specs::ebml_specification]
+            #(#attrs)*
+            #visibility enum #ident {
+                #(#variants),*
+            }
+        ))
+    }
+}
+
+pub struct EasyEBMLVariant {
+    path: Punctuated<Ident, Token![/]>,
+    ty: Ident,
+    id: LitInt
+}
+
+impl EasyEBMLVariant {
+    pub fn into_variant(self) -> Result<Variant> {
+        let EasyEBMLVariant { mut path, ty, id } = self;
+        let ident = path.pop().ok_or_else(|| Error::new(path.span(), "easy_ebml enum variant must be at least: `Name: Type = id`"))?.into_value();
+        let mut attrs = vec![];
+        attrs.push(Attribute {
+            pound_token: Default::default(),
+            style: AttrStyle::Outer,
+            bracket_token: Default::default(),
+            path: Ident::new("id", proc_macro2::Span::call_site()).into(),
+            tokens: quote!((#id))
+        });
+        attrs.push(Attribute {
+            pound_token: Default::default(),
+            style: AttrStyle::Outer,
+            bracket_token: Default::default(),
+            path: Ident::new("data_type", proc_macro2::Span::call_site()).into(),
+            tokens: quote!((TagDataType::#ty))
+        });
+
+        if let Some(it) = path.pop() {
+            let it = it.into_value();
+            attrs.push(Attribute {
+                pound_token: Default::default(),
+                style: AttrStyle::Outer,
+                bracket_token: Default::default(),
+                path: Ident::new("parent", proc_macro2::Span::call_site()).into(),
+                tokens: quote!((#it))
+            });
+        }
+
+        Ok(Variant {
+            attrs,
+            ident,
+            fields: syn::Fields::Unit,
+            discriminant: None
+        })
+    }
+}
+
+impl Parse for EasyEBMLVariant {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let path = Punctuated::parse_separated_nonempty(input)?;
+        input.parse::<Token![:]>()?;
+        let ty: Ident = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let id: LitInt = input.parse()?;
+        Ok(Self {
+            path,
+            ty,
+            id
+        })
+    }
+}

--- a/specification-derive/src/easy_ebml.rs
+++ b/specification-derive/src/easy_ebml.rs
@@ -34,7 +34,6 @@ impl Parse for EasyEBML {
 }
 
 impl EasyEBML {
-
     pub fn implement(self) -> Result<TokenStream> {
         let EasyEBML { attrs, visibility, ident, variants } = self;
 

--- a/specification-derive/src/easy_ebml.rs
+++ b/specification-derive/src/easy_ebml.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use syn::{Attribute, AttrStyle, Ident, LitInt, parse::Parse, Path, Token, Variant, Visibility};
+use syn::{Attribute, AttrStyle, Ident, LitInt, parse::Parse, Token, Variant, Visibility};
 use syn::parse::{ParseBuffer, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::Result;

--- a/specification-derive/src/lib.rs
+++ b/specification-derive/src/lib.rs
@@ -9,18 +9,23 @@ use syn::{ItemEnum, Error};
 use crate::easy_ebml::EasyEBML;
 
 ///
-/// Attribute that derives implementations of EbmlSpecification and EbmlTag for an enum.
+/// Attribute that derives implementations of [`EbmlSpecification`][spec] and [`EbmlTag`][tag] for an enum.
 ///
-/// This macro is intended to make implementing the traits in ebml-iterable-specification easier to manage.  Rather than requiring handwritten implementations for `EbmlSpecification` and `EbmlTag` methods, this macro understands attributes assigned to enum members and generates an implementation accordingly.
+/// This macro is intended to make implementing the traits in ebml-iterable-specification easier to manage.  Rather than requiring handwritten implementations for [`EbmlSpecification`][spec] and [`EbmlTag`][tag] methods, this macro understands attributes assigned to enum members and generates an implementation accordingly.
 ///
 /// When deriving `EbmlSpecification` for an enum, the following attributes are required for each variant:
 ///   * __#[id(`u64`)]__ - This attribute specifies the "id" of the tag. e.g. `0x1a45dfa3`
 ///   * __#[data_type(`TagDataType`)]__ - This attribute specifies the type of data contained in the tag. e.g. `TagDataType::UnsignedInt`
 ///
+/// The following attribute is optional for each variant:
+///   * __#[parent(OtherVariantName)]__ - This attribute specifies the direct ancestor of the current element.  If this attribute is not present, the variant is treated as a Root element.
+/// 
 /// # Note
 ///
 /// This attribute modifies the variants in the enumeration by adding fields to them.  It also will add a `RawTag(u64, Vec<u8>)` variant to the enumeration.
 ///
+/// [spec]: ebml_iterable_specification::EbmlSpecification
+/// [tag]: ebml_iterable_specification::EbmlTag
 
 #[proc_macro_attribute]
 pub fn ebml_specification(_args: TokenStream, input: TokenStream) -> TokenStream {
@@ -36,6 +41,67 @@ pub fn ebml_specification(_args: TokenStream, input: TokenStream) -> TokenStream
         .into()
 }
 
+///
+/// Macro that makes writing an EBML spec easy.
+/// 
+/// This provides an even easier alternative to create implementations of the [`EbmlSpecification`][spec] and [`EbmlTag`][tag] traits than using the [`[#ebml_specification]`][macro] attribute.  As a bonus, your spec will be more legible and maintainable!
+/// 
+/// As an example, compare the following equivalent definitions:
+/// ```
+/// # use ebml_iterable_specification_derive::ebml_specification;
+/// # use ebml_iterable_specification::TagDataType::{Master, UnsignedInt};
+/// # pub mod ebml_iterable { pub mod specs { 
+/// #    pub use ebml_iterable_specification_derive::ebml_specification as ebml_specification; 
+/// #    pub use ebml_iterable_specification::EbmlSpecification as EbmlSpecification;
+/// #    pub use ebml_iterable_specification::EbmlTag as EbmlTag;
+/// #    pub use ebml_iterable_specification::TagDataType as TagDataType;
+/// #    pub use ebml_iterable_specification::Master as Master;
+/// # }}
+/// #[ebml_specification]
+/// #[derive(Clone)]
+/// enum Example {
+///   #[id(0x01)]
+///   #[data_type(Master)]
+///   Root,
+///
+///   #[id(0x02)]
+///   #[data_type(Master)]
+///   #[parent(Root)]
+///   Parent,
+///
+///   #[id(0x100)]
+///   #[data_type(UnsignedInt)]
+///   #[parent(Parent)]
+///   Data,
+/// }
+/// ```
+/// vs
+/// ```
+/// # use ebml_iterable_specification_derive::easy_ebml;
+/// # use ebml_iterable_specification::TagDataType;
+/// # use ebml_iterable_specification::TagDataType::{Master, UnsignedInt};
+/// # pub mod ebml_iterable { pub mod specs { 
+/// #    pub use ebml_iterable_specification_derive::ebml_specification as ebml_specification; 
+/// #    pub use ebml_iterable_specification::EbmlSpecification as EbmlSpecification;
+/// #    pub use ebml_iterable_specification::EbmlTag as EbmlTag;
+/// #    pub use ebml_iterable_specification::TagDataType as TagDataType;
+/// #    pub use ebml_iterable_specification::Master as Master;
+/// # }}
+/// easy_ebml! {
+///   #[derive(Clone)]
+///   enum Example {
+///     Root                : Master = 0x01,
+///     Root/Parent         : Master = 0x02,
+///     Root/Parent/Data    : UnsignedInt = 0x100,
+///   }
+/// }
+/// ```
+/// 
+/// Behind the scenes `easy_ebml!` still uses the existing [`[#ebml_specification]`][macro] attribute macro, so the final output of this macro will remain identical.
+/// 
+/// [spec]: ebml_iterable_specification::EbmlSpecification
+/// [tag]: ebml_iterable_specification::EbmlTag
+/// [macro]: macro@crate::ebml_specification
 
 #[proc_macro]
 pub fn easy_ebml(input: TokenStream) -> TokenStream {

--- a/specification-derive/src/lib.rs
+++ b/specification-derive/src/lib.rs
@@ -2,19 +2,21 @@ extern crate proc_macro;
 
 mod ast;
 mod attr;
+mod easy_ebml;
 
 use proc_macro::TokenStream;
 use syn::{ItemEnum, Error};
+use crate::easy_ebml::EasyEBML;
 
 ///
 /// Attribute that derives implementations of EbmlSpecification and EbmlTag for an enum.
-/// 
+///
 /// This macro is intended to make implementing the traits in ebml-iterable-specification easier to manage.  Rather than requiring handwritten implementations for `EbmlSpecification` and `EbmlTag` methods, this macro understands attributes assigned to enum members and generates an implementation accordingly.
-/// 
+///
 /// When deriving `EbmlSpecification` for an enum, the following attributes are required for each variant:
 ///   * __#[id(`u64`)]__ - This attribute specifies the "id" of the tag. e.g. `0x1a45dfa3`
 ///   * __#[data_type(`TagDataType`)]__ - This attribute specifies the type of data contained in the tag. e.g. `TagDataType::UnsignedInt`
-/// 
+///
 /// # Note
 ///
 /// This attribute modifies the variants in the enumeration by adding fields to them.  It also will add a `RawTag(u64, Vec<u8>)` variant to the enumeration.
@@ -32,4 +34,24 @@ pub fn ebml_specification(_args: TokenStream, input: TokenStream) -> TokenStream
     attr::impl_ebml_specification(&mut input)
         .unwrap_or_else(|err| err.to_compile_error())
         .into()
+}
+
+
+#[proc_macro]
+pub fn easy_ebml(input: TokenStream) -> TokenStream {
+    let input = match syn::parse::<EasyEBML>(input) {
+        Ok(syntax_tree) => syntax_tree,
+        Err(err) => {
+            return TokenStream::from(Error::new(err.span(), "easy_ebml! {} content must be of format: enum Name {\
+                Root: Type = id,\
+                Path/Of/Component: Type = id,\
+                // example\
+                Crc32: Binary = 0xbf,\
+                Ebml: Master = 0x1a45dfa3,\
+                Ebml/EbmlVersion: UnsignedInt = 0x4286,\
+            }").to_compile_error())
+        },
+    };
+
+    input.implement().unwrap_or_else(|err| err.to_compile_error()).into()
 }

--- a/specification/Cargo.toml
+++ b/specification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebml-iterable-specification"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Austin Blake <austinl3roy@gmail.com>"]
 edition = "2018"
 description = "Provides the base `EbmlSpecification` used by the `ebml-iterable` and `ebml-iterable-specification-derive` crates."

--- a/specification/src/empty_spec.rs
+++ b/specification/src/empty_spec.rs
@@ -72,6 +72,10 @@ impl EbmlTag<EmptySpec> for EmptySpec {
         self.id
     }
 
+    fn get_parent_id(&self) -> Option<u64> {
+        None
+    }
+
     fn as_unsigned_int(&self) -> Option<&u64> {
         None
     }
@@ -97,11 +101,5 @@ impl EbmlTag<EmptySpec> for EmptySpec {
             Some(children) => Some(children),
             None => None
         }
-    }
-
-    fn is_child(&self, id: u64) -> bool {
-        // This assumes we know there are no unknown or unexpected elements
-        // To correctly be implemented, this should know all parent, root and sibling elements and return false if it is one of them, because spec requires them to be the only stop conditions.
-        self.children.iter().any(|it|it.clone().get_children().iter().any(|it|it.id == id))
     }
 }

--- a/specification/src/empty_spec.rs
+++ b/specification/src/empty_spec.rs
@@ -98,4 +98,10 @@ impl EbmlTag<EmptySpec> for EmptySpec {
             None => None
         }
     }
+
+    fn is_child(&self, id: u64) -> bool {
+        // This assumes we know there are no unknown or unexpected elements
+        // To correctly be implemented, this should know all parent, root and sibling elements and return false if it is one of them, because spec requires them to be the only stop conditions.
+        self.children.iter().any(|it|it.clone().get_children().iter().any(|it|it.id == id))
+    }
 }

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -119,6 +119,11 @@ pub trait EbmlTag<T: Clone> {
     ///
     fn get_id(&self) -> u64;
 
+    ///
+    /// Gets the id of the parent of `self`, if any.
+    /// 
+    /// This function is used to find the id of the direct ancestor of the current tag.  If the current tag is a root element, this function should return `None`.
+    /// 
     fn get_parent_id(&self) -> Option<u64>;
 
     ///

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -101,12 +101,6 @@ pub trait EbmlSpecification<T: EbmlSpecification<T> + EbmlTag<T> + Clone> {
     ///
     fn get_raw_tag(id: u64, data: &[u8]) -> T;
 
-    ///
-    /// Tests if [id] is a root element
-    ///
-    /// Used to determine if Unknown size blocks should end
-    ///
-    fn is_root(id: u64) -> bool;
 }
 
 ///
@@ -170,16 +164,14 @@ pub trait EbmlTag<T: Clone> {
     ///
     /// Tests if [id] is a child of self
     ///
-    /// Used to determine if Unknown size blocks should end
+    /// Default is [true]
+    /// Unknown or unexpected elements are children. Global elements are children.
+    ///
+    /// Used to determine if Unknown size blocks should end. If [is_child] returns false, the Unknown size block ends.
+    ///
+    /// [`Spec`](https://github.com/ietf-wg-cellar/ebml-specification/blob/master/specification.markdown#unknown-data-size) does not explicitly state what to do in case of an unexpected element, so we assume it will be handled like a child element since it is not one of the end conditions.
     ///
     fn is_child(&self, id: u64) -> bool;
-
-    ///
-    /// Tests if [id] is a parent of self
-    ///
-    /// Used to determine if Unknown size blocks should end
-    ///
-    fn is_parent(&self, id: u64) -> bool;
 }
 
 ///

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -165,6 +165,7 @@ pub trait EbmlTag<T: Clone> {
     /// Tests if [id] is a child of self
     ///
     /// Default is [true]
+    ///
     /// Unknown or unexpected elements are children. Global elements are children.
     ///
     /// Used to determine if Unknown size blocks should end. If [is_child] returns false, the Unknown size block ends.

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -1,5 +1,5 @@
 //! This crate provides a core ebml specification that is used by the ebml-iterable crate.
-//! 
+//!
 //! The related ebml-iterable-specification-derive crate can be used to simplify implementation of this spec.
 //!
 
@@ -10,11 +10,11 @@ pub mod empty_spec;
 
 ///
 /// Different data types defined in the EBML specification.
-/// 
-/// # Notes 
+///
+/// # Notes
 ///
 /// This library made a concious decision to not work with "Date" elements from EBML due to lack of built-in support for dates in Rust. Specification implementations should treat Date elements as Binary so that consumers have the option of parsing the unaltered data using their library of choice, if needed.
-/// 
+///
 
 // Possible future feature flag to enable Date functionality by having `chrono` as an optional dependency?
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -29,7 +29,7 @@ pub enum TagDataType {
 
 ///
 /// This trait, along with [`EbmlTag`], should be implemented to define a specification so that EBML can be parsed correctly.  Typically implemented on an Enum of tag variants.
-/// 
+///
 /// Any specification using EBML can take advantage of this library to parse or write binary data.  As stated in the docs, [`TagWriter`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagWriter.html) needs nothing special if you stick with the `write_raw` method, but [`TagIterator`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagIterator.html) requires a struct implementing this trait.  Custom specification implementations can refer to [webm-iterable](https://crates.io/crates/webm_iterable) as an example.
 ///
 /// This trait and [`EbmlTag`] are typically implemented simultaneously.  They are separate traits as they have primarily different uses - [`EbmlSpecification`] should be brought into scope when dealing with the specification as a whole, whereas [`EbmlTag`] should be brought into scope when dealing with specific tags.
@@ -42,7 +42,7 @@ pub trait EbmlSpecification<T: EbmlSpecification<T> + EbmlTag<T> + Clone> {
     /// This function *must* return [`TagDataType::Binary`] if the input id is not in the specification.  Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_tag_data_type(id: u64) -> TagDataType;
-    
+
     ///
     /// Gets the id of a specific tag variant.
     ///
@@ -51,60 +51,67 @@ pub trait EbmlSpecification<T: EbmlSpecification<T> + EbmlTag<T> + Clone> {
     fn get_tag_id(item: &T) -> u64 {
         item.get_id()
     }
-    
+
     ///
-    /// Creates an unsigned integer type tag from the spec.  
+    /// Creates an unsigned integer type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::UnsignedInt`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_unsigned_int_tag(id: u64, data: u64) -> Option<T>;
-    
+
     ///
-    /// Creates a signed integer type tag from the spec.  
+    /// Creates a signed integer type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Integer`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_signed_int_tag(id: u64, data: i64) -> Option<T>;
-    
+
     ///
-    /// Creates a utf8 type tag from the spec.  
+    /// Creates a utf8 type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Utf8`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_utf8_tag(id: u64, data: String) -> Option<T>;
-    
+
     ///
-    /// Creates a binary type tag from the spec.  
+    /// Creates a binary type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Binary`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_binary_tag(id: u64, data: &[u8]) -> Option<T>;
-    
+
     ///
-    /// Creates a float type tag from the spec.  
+    /// Creates a float type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Float`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_float_tag(id: u64, data: f64) -> Option<T>;
-    
+
     ///
-    /// Creates a master type tag from the spec.  
+    /// Creates a master type tag from the spec.
     ///
     /// This function *must* return `None` if the input id is not in the specification or if the input id data type is not [`TagDataType::Master`]. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_master_tag(id: u64, data: Master<T>) -> Option<T>;
 
     ///
-    /// Creates a tag that does not conform to the spec. 
+    /// Creates a tag that does not conform to the spec.
     ///
     /// This function should return a "RawTag" variant that contains the tag id and tag data.  Tag data should only be retrievable as binary data. Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn get_raw_tag(id: u64, data: &[u8]) -> T;
+
+    ///
+    /// Tests if [id] is a root element
+    ///
+    /// Used to determine if Unknown size blocks should end
+    ///
+    fn is_root(id: u64) -> bool;
 }
 
 ///
 /// This trait, along with [`EbmlSpecification`], should be implemented to define a specification so that EBML can be parsed correctly.  Typically implemented on an Enum of tag variants.
-/// 
+///
 /// Any specification using EBML can take advantage of this library to parse or write binary data.  As stated in the docs, [`TagWriter`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagWriter.html) needs nothing special if you stick with the `write_raw` method, but [`TagIterator`](https://docs.rs/ebml-iterable/latest/ebml_iterable/struct.TagIterator.html) requires a struct implementing this trait.  Custom specification implementations can refer to [webm-iterable](https://crates.io/crates/webm_iterable) as an example.
 ///
 /// This trait and [`EbmlSpecification`] are typically implemented simultaneously.  They are separate traits as they have primarily different uses - [`EbmlSpecification`] should be brought into scope when dealing with the specification as a whole, whereas [`EbmlTag`] should be brought into scope when dealing with specific tags.
@@ -159,6 +166,20 @@ pub trait EbmlTag<T: Clone> {
     /// This function *must* return `None` if the associated data type of `self` is not [`TagDataType::Master`].  Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn as_master(&self) -> Option<&Master<T>>;
+
+    ///
+    /// Tests if [id] is a child of self
+    ///
+    /// Used to determine if Unknown size blocks should end
+    ///
+    fn is_child(&self, id: u64) -> bool;
+
+    ///
+    /// Tests if [id] is a parent of self
+    ///
+    /// Used to determine if Unknown size blocks should end
+    ///
+    fn is_parent(&self, id: u64) -> bool;
 }
 
 ///

--- a/specification/src/lib.rs
+++ b/specification/src/lib.rs
@@ -119,6 +119,8 @@ pub trait EbmlTag<T: Clone> {
     ///
     fn get_id(&self) -> u64;
 
+    fn get_parent_id(&self) -> Option<u64>;
+
     ///
     /// Gets a reference to the data contained in `self` as an unsigned integer.
     ///
@@ -160,19 +162,6 @@ pub trait EbmlTag<T: Clone> {
     /// This function *must* return `None` if the associated data type of `self` is not [`TagDataType::Master`].  Implementors can reference [webm-iterable](https://crates.io/crates/webm_iterable) for an example.
     ///
     fn as_master(&self) -> Option<&Master<T>>;
-
-    ///
-    /// Tests if [id] is a child of self
-    ///
-    /// Default is [true]
-    ///
-    /// Unknown or unexpected elements are children. Global elements are children.
-    ///
-    /// Used to determine if Unknown size blocks should end. If [is_child] returns false, the Unknown size block ends.
-    ///
-    /// [`Spec`](https://github.com/ietf-wg-cellar/ebml-specification/blob/master/specification.markdown#unknown-data-size) does not explicitly state what to do in case of an unexpected element, so we assume it will be handled like a child element since it is not one of the end conditions.
-    ///
-    fn is_child(&self, id: u64) -> bool;
 }
 
 ///

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -96,7 +96,7 @@ pub mod tag_iterator {
                 TagIteratorError::CorruptedTagData {
                     tag_id,
                     problem,
-                } => write!(f, "Error reading data for tag id ({}). {}", tag_id, problem),
+                } => write!(f, "Error reading data for tag id (0x{:x?}). {}", tag_id, problem),
                 TagIteratorError::ReadError { source: _ } => write!(f, "Error reading from source."),
             }
         }
@@ -164,8 +164,8 @@ pub mod tag_writer {
             match self {
                 TagWriterError::TagSizeError(message) => write!(f, "Problem writing data tag size. {}", message),
                 TagWriterError::UnexpectedClosingTag { tag_id, expected_id } => match expected_id {
-                    Some(expected) => write!(f, "Unexpected closing tag '{}'. Expected '{}'", tag_id, expected),
-                    None => write!(f, "Unexpected closing tag '{}'", tag_id),
+                    Some(expected) => write!(f, "Unexpected closing tag 0x'{:x?}'. Expected 0x'{:x?}'", tag_id, expected),
+                    None => write!(f, "Unexpected closing tag 0x'{:x?}'", tag_id),
                 },
                 TagWriterError::WriteError { source: _ } => write!(f, "Error writing to destination."),
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -127,7 +127,9 @@ pub mod tag_writer {
         ///
         /// An error with the size of a tag.
         ///
-        /// Can occur if the tag size overflows the max value representable by a vint (`2^57 - 1`, or `144,115,188,075,855,871`).  Typically this won't happen - this variant is included for completeness.
+        /// Can occur if the tag size overflows the max value representable by a vint (`2^57 - 1`, or `144,115,188,075,855,871`).
+        /// 
+        /// This can also occur if a non-[`Master`][`crate::specs::TagDataType::Master`] tag is sent to be written with an unknown size.
         ///
         TagSizeError(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,43 +1,43 @@
 //! This crate provides an iterator and a serializer for [EBML][EBML] files.  Its primary goal is to provide typed iteration and serialization as lightly and quickly as possible.
-//! 
+//!
 //! [EBML][EBML] stands for Extensible Binary Meta-Language and is somewhat of a
 //! binary version of XML. It's used for container formats like [WebM][webm] or
 //! [MKV][mkv].
-//! 
+//!
 //! # Important - Specifications
 //! The iterator contained in this crate is spec-agnostic and requires a specification implementing the [`specs::EbmlSpecification`] and [`specs::EbmlTag`] traits to read files.  Typically, you would only use this crate to implement a custom specification - most often you would prefer a crate providing an existing specification, like [webm-iterable][webm-iterable].
-//! 
-//! Implementing custom specifications can be made less painful by enabling the `"derive-spec"` feature flag in this crate and using the [`#[ebml_specification]`](https://docs.rs/ebml-iterable-specification-derive/latest/ebml_iterable_specification_derive/attr.ebml_specification.html) macro.
-//! 
+//!
+//! Implementing custom specifications can be made less painful and safer by enabling the `"derive-spec"` feature flag in this crate and using the [`#[ebml_specification]`](https://docs.rs/ebml-iterable-specification-derive/latest/ebml_iterable_specification_derive/attr.ebml_specification.html) macro.
+//!
 //! # Features
-//! 
+//!
 //! There is currently only one optional feature in this crate, but that may change over time as needs arise.
-//! 
+//!
 //! * **derive-spec** -
 //!     When enabled, this provides the [`#[ebml_specification]`](https://docs.rs/ebml-iterable-specification-derive/latest/ebml_iterable_specification_derive/attr.ebml_specification.html) attribute macro to simplify implementation of the [`EbmlSpecification`][`specs::EbmlSpecification`] and [`EbmlTag`][`specs::EbmlTag`] traits.  This introduces dependencies on [`syn`](https://crates.io/crates/syn), [`quote`](https://crates.io/crates/quote), and [`proc-macro2`](https://crates.io/crates/proc-macro2), so expect compile times to increase a little.
-//! 
-//! # Known Limitations
-//! This library was not built to work with an "Unknown Data Size" as defined in [RFC8794][rfc8794]. As such, it likely will not support streaming applications and will only work on complete datasets.
-//! 
+//!
 //! [EBML]: http://ebml.sourceforge.net/
 //! [webm]: https://www.webmproject.org/
 //! [mkv]: http://www.matroska.org/technical/specs/index.html
 //! [rfc8794]: https://datatracker.ietf.org/doc/rfc8794/
 //! [webm-iterable]: https://crates.io/crates/webm_iterable
-//! 
+//!
 
 mod errors;
 mod tag_iterator;
+mod tag_iterator_async;
 mod tag_writer;
 pub mod tools;
 pub mod specs;
+mod tag_iterator_util;
 
 pub use self::tag_iterator::TagIterator;
+pub use self::tag_iterator_async::TagIteratorAsync;
 pub use self::tag_writer::TagWriter;
 
 pub mod error {
 
-    //! 
+    //!
     //! Potential errors that can occur when reading or writing EBML data.
     //!
     pub use super::errors::tag_iterator::TagIteratorError;
@@ -46,5 +46,5 @@ pub mod error {
     ///
     /// Error details that may be included in some thrown errors
     ///
-    pub use super::errors::tool::ToolError; 
+    pub use super::errors::tool::ToolError;
 }

--- a/src/specs.rs
+++ b/src/specs.rs
@@ -1,11 +1,13 @@
 //!
 //! Provides the EBML specification types.
-//! 
+//!
 //! Typically won't be used unless you are implementing a custom specification that uses EBML.  You can enable the `"derive-spec"` feature to obtain a macro to make implementation easier.
-//! 
+//!
 
 #[cfg(feature = "derive-spec")]
 pub use ebml_iterable_specification_derive::ebml_specification;
+#[cfg(feature = "derive-spec")]
+pub use ebml_iterable_specification_derive::easy_ebml;
 
 pub use ebml_iterable_specification::EbmlSpecification as EbmlSpecification;
 pub use ebml_iterable_specification::EbmlTag as EbmlTag;

--- a/src/tag_iterator.rs
+++ b/src/tag_iterator.rs
@@ -193,7 +193,7 @@ impl<'a, R: Read, TSpec> TagIterator<R, TSpec>
             let raw_data = if let Known(size) = size {
                 self.read_tag_data(size)?
             } else {
-                unreachable!("Unknown size for primitive or buffered tags is not allowed")
+                return Err(TagIteratorError::CorruptedFileData("Unknown size for primitive tag not allowed".into()));
             };
 
             let tag = match spec_tag_type {
@@ -244,7 +244,6 @@ impl<'a, R: Read, TSpec> TagIterator<R, TSpec>
                     }
                 }
             }
-
         }
     }
 }

--- a/src/tag_iterator.rs
+++ b/src/tag_iterator.rs
@@ -226,25 +226,25 @@ impl<'a, R: Read, TSpec> TagIterator<R, TSpec>
                 },
             };
 
-            let previous_tag_ended = {
-                match self.tag_stack.last() {
-                    None => true,
-                    Some(previous_tag) => {
+            match self.tag_stack.last() {
+                None => Ok(tag),
+                Some(previous_tag) => {
+                    let previous_tag_ended =
                         previous_tag.is_parent(tag_id) ||
                         previous_tag.is_sibling(&tag) ||
                         (
                             std::mem::discriminant(&tag) != std::mem::discriminant(&TSpec::get_raw_tag(tag_id, &[])) && 
                             matches!(tag.get_parent_id(), None)
-                        )
+                        );
+
+                    if previous_tag_ended {
+                        Ok(mem::replace(self.tag_stack.last_mut().unwrap(), ProcessingTag { tag, size, start: current_offset }).into_inner())
+                    } else {
+                        Ok(tag)
                     }
                 }
-            };
-
-            if previous_tag_ended {
-                Ok(mem::replace(self.tag_stack.last_mut().unwrap(), ProcessingTag { tag, size, start: current_offset }).into_inner())
-            } else {
-                Ok(tag)
             }
+
         }
     }
 }

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -188,7 +188,7 @@ impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
         Some(self.read_tag().await)
     }
 
-    pub async fn into_stream(self) -> impl Stream<Item=Result<TSpec, TagIteratorError>> {
+    pub fn into_stream(self) -> impl Stream<Item=Result<TSpec, TagIteratorError>> {
         futures::stream::unfold(self, |mut read| async {
             let next = read.next().await;
             next.map(move |it| (it, read))

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -103,7 +103,7 @@ impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
             let size = if let Known(size) = size {
                 size
             } else {
-                unreachable!("Unknown size for primitive not allowed")
+                return Err(TagIteratorError::CorruptedFileData("Unknown size for primitive not allowed".into()));
             };
             let raw_data = self.read_tag_data(size).await?;
             match spec_tag_type {

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -1,0 +1,163 @@
+use std::iter::repeat;
+use std::mem;
+use ebml_iterable_specification::{EbmlSpecification, EbmlTag, Master, TagDataType};
+use futures::{AsyncRead, AsyncReadExt, Stream};
+use crate::error::{TagIteratorError, ToolError};
+use crate::tag_iterator_util::{EBMLSize, ProcessingTag};
+use crate::tag_iterator_util::EBMLSize::Known;
+use crate::tag_iterator_util::ProcessingTag::{EndTag, NextTag};
+use crate::tools;
+
+pub struct TagIteratorAsync<R: AsyncRead + Unpin, TSpec>
+    where
+        TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
+{
+    read: R,
+    buf: Vec<u8>,
+    offset: usize,
+    tag_stack: Vec<ProcessingTag<TSpec>>
+}
+
+impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
+    where
+        TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
+{
+
+    fn new(read: R) -> Self {
+        Self {
+            read,
+            buf: Default::default(),
+            offset: 0,
+            tag_stack: Default::default()
+        }
+    }
+
+    fn current_offset(&self) -> usize {
+        self.offset
+    }
+
+    fn advance(&mut self, length: usize) {
+        self.offset += length;
+        self.buf.drain(0..length);
+    }
+
+    fn advance_get(&mut self, length: usize) -> Vec<u8> {
+        self.offset += length;
+        let upper = self.buf.split_off(length);
+        mem::replace(&mut self.buf, upper)
+    }
+
+    async fn ensure_data_read(&mut self, len: usize) -> Result<bool, TagIteratorError> {
+        let size = self.buf.len();
+        if size < len {
+            let remaining = len - size;
+            self.buf.extend(repeat(0).take(remaining));
+            self.read.read_exact(&mut self.buf[size..]).await.map_err(|source| TagIteratorError::ReadError { source })?
+        }
+        Ok(true)
+    }
+
+    async fn read_tag_id(&mut self) -> Result<u64, TagIteratorError> {
+        self.ensure_data_read(8).await?;
+        match tools::read_vint(&self.buf).map_err(|e| TagIteratorError::CorruptedFileData(e.to_string()))? {
+            Some((value, length)) => {
+                self.advance(length);
+                Ok(value + (1 << (7 * length)))
+            },
+            None => Err(TagIteratorError::CorruptedFileData(String::from("Expected tag id, but reached end of source."))),
+        }
+    }
+
+    async fn read_tag_size(&mut self) -> Result<EBMLSize, TagIteratorError> {
+        self.ensure_data_read(8).await?;
+        match tools::read_vint(&self.buf).map_err(|e| TagIteratorError::CorruptedFileData(e.to_string()))? {
+            Some((value, length)) => {
+                self.advance(length);
+                Ok(value.into())
+            },
+            None => Err(TagIteratorError::CorruptedFileData(String::from("Expected tag size, but reached end of source."))),
+        }
+    }
+
+    async fn read_tag_data(&mut self, size: usize) -> Result<Vec<u8>, TagIteratorError> {
+        if !self.ensure_data_read(size).await? {
+            return Err(TagIteratorError::CorruptedFileData(String::from("reached end of file but expecting more data")));
+        }
+        Ok(self.advance_get(size))
+    }
+
+    async fn read_tag(&mut self) -> Result<TSpec, TagIteratorError> {
+        let tag_id = self.read_tag_id().await?;
+        let spec_tag_type = TSpec::get_tag_data_type(tag_id);
+        let size = self.read_tag_size().await?;
+
+        let is_master = matches!(spec_tag_type, TagDataType::Master);
+        let tag = if is_master {
+            self.tag_stack.push(EndTag {
+                tag: TSpec::get_master_tag(tag_id, Master::End).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was master, but could not get tag!", tag_id)),
+                size,
+                start: self.current_offset(),
+            });
+            TSpec::get_master_tag(tag_id, Master::Start).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was master, but could not get tag!", tag_id))
+        } else {
+            let size = if let Known(size) = size {
+                size
+            } else {
+                unreachable!("Unknown size for primitive not allowed")
+            };
+            let raw_data = self.read_tag_data(size).await?;
+            match spec_tag_type {
+                TagDataType::Master => { unreachable!("Master should have been handled before querying data") },
+                TagDataType::UnsignedInt => {
+                    let val = tools::arr_to_u64(&raw_data).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: e })?;
+                    TSpec::get_unsigned_int_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was unsigned int, but could not get tag!", tag_id))
+                },
+                TagDataType::Integer => {
+                    let val = tools::arr_to_i64(&raw_data).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: e })?;
+                    TSpec::get_signed_int_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was integer, but could not get tag!", tag_id))
+                },
+                TagDataType::Utf8 => {
+                    let val = String::from_utf8(raw_data.to_vec()).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: ToolError::FromUtf8Error(raw_data, e) })?;
+                    TSpec::get_utf8_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was utf8, but could not get tag!", tag_id))
+                },
+                TagDataType::Binary => {
+                    TSpec::get_binary_tag(tag_id, &raw_data).unwrap_or_else(|| TSpec::get_raw_tag(tag_id, &raw_data))
+                },
+                TagDataType::Float => {
+                    let val = tools::arr_to_f64(&raw_data).map_err(|e| TagIteratorError::CorruptedTagData{ tag_id, problem: e })?;
+                    TSpec::get_float_tag(tag_id, val).unwrap_or_else(|| panic!("Bad specification implementation: Tag id {} type was float, but could not get tag!", tag_id))
+                },
+            }
+        };
+
+        if self.tag_stack.last().map(|it| tag.is_child(it.get_id())).unwrap_or(true) {
+            Ok(tag)
+        } else {
+            Ok(mem::replace(self.tag_stack.last_mut().unwrap(), NextTag { tag }).into_inner())
+        }
+    }
+
+    pub async fn next(&mut self) -> Option<Result<TSpec, TagIteratorError>> {
+        if let Some(tag) = self.tag_stack.pop() {
+            match tag {
+                EndTag { size, start, tag } => {
+                    if let Known(size) = size {
+                        if self.current_offset() >= start + size {
+                            return Some(Ok(tag));
+                        }
+                    }
+                    self.tag_stack.push(EndTag { size, start, tag });
+                },
+                NextTag { tag } => return Some(Ok(tag))
+            }
+        }
+        Some(self.read_tag().await)
+    }
+
+    pub async fn into_stream(self) -> impl Stream<Item=Result<TSpec, TagIteratorError>> {
+        futures::stream::unfold(self, |mut read| async {
+            let next = read.next().await;
+            next.map(move |it| (it, read))
+        })
+    }
+}

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -85,7 +85,7 @@ impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
         match tools::read_vint(&self.buf).map_err(|e| TagIteratorError::CorruptedFileData(e.to_string()))? {
             Some((value, length)) => {
                 self.advance(length);
-                Ok(value.into())
+                Ok(EBMLSize::new(value, length))
             },
             None => Err(TagIteratorError::CorruptedFileData(String::from("Expected tag size, but reached end of source."))),
         }

--- a/src/tag_iterator_async.rs
+++ b/src/tag_iterator_async.rs
@@ -23,7 +23,7 @@ impl<R: AsyncRead + Unpin, TSpec> TagIteratorAsync<R, TSpec>
         TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
 {
 
-    fn new(read: R) -> Self {
+    pub fn new(read: R) -> Self {
         Self {
             read,
             buf: Default::default(),

--- a/src/tag_iterator_util.rs
+++ b/src/tag_iterator_util.rs
@@ -29,6 +29,7 @@ impl EBMLSize {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
 pub struct ProcessingTag<TSpec>
     where TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
 {

--- a/src/tag_iterator_util.rs
+++ b/src/tag_iterator_util.rs
@@ -1,0 +1,64 @@
+use ebml_iterable_specification::{EbmlSpecification, EbmlTag};
+use std::convert::TryInto;
+use crate::tag_iterator_util::EBMLSize::{Known, Unknown};
+use crate::tag_iterator_util::ProcessingTag::{EndTag, NextTag};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum EBMLSize {
+    Known(usize),
+    Unknown
+}
+
+impl From<u64> for EBMLSize {
+    fn from(size: u64) -> Self {
+        Self::new(size)
+    }
+}
+
+impl EBMLSize {
+
+    pub fn new(size: u64) -> Self {
+        const UNKNOWN: u64 = u64::MAX >> 8;
+        if size == UNKNOWN {
+            return Unknown
+        } else {
+            match size.try_into() {
+                Ok(value) => Known(value),
+                Err(_) => Unknown
+            }
+        }
+    }
+
+}
+
+pub enum ProcessingTag<TSpec>
+    where TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone
+{
+    EndTag {
+        tag: TSpec,
+        size: EBMLSize,
+        start: usize,
+    },
+    NextTag {
+        tag: TSpec,
+    }
+}
+
+impl<TSpec> ProcessingTag<TSpec> where TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone {
+
+    pub fn get_id(&self) -> u64 {
+        match self {
+            EndTag { tag,.. } => tag.get_id(),
+            NextTag { tag } => tag.get_id()
+        }
+    }
+
+    pub fn into_inner(self) -> TSpec {
+        match self {
+            EndTag { tag,.. } => tag,
+            NextTag { tag } => tag
+        }
+    }
+}
+
+pub const DEFAULT_BUFFER_LEN: usize = 1024 * 64;

--- a/src/tag_iterator_util.rs
+++ b/src/tag_iterator_util.rs
@@ -8,22 +8,23 @@ pub enum EBMLSize {
     Unknown
 }
 
-impl From<u64> for EBMLSize {
-    fn from(size: u64) -> Self {
-        Self::new(size)
-    }
-}
-
 impl EBMLSize {
-    pub fn new(size: u64) -> Self {
-        const UNKNOWN: u64 = u64::MAX >> 8;
-        if size == UNKNOWN {
-            Unknown
-        } else {
-            match size.try_into() {
-                Ok(value) => Known(value),
-                Err(_) => Unknown
-            }
+    pub fn new(size: u64, vint_length: usize) -> Self {
+        match vint_length {
+            1 => if size == ((1 << (7))     - 1) { return Unknown; },
+            2 => if size == ((1 << (7 * 2)) - 1) { return Unknown; },
+            3 => if size == ((1 << (7 * 3)) - 1) { return Unknown; },
+            4 => if size == ((1 << (7 * 4)) - 1) { return Unknown; },
+            5 => if size == ((1 << (7 * 5)) - 1) { return Unknown; },
+            6 => if size == ((1 << (7 * 6)) - 1) { return Unknown; },
+            7 => if size == ((1 << (7 * 7)) - 1) { return Unknown; },
+            8 => if size == ((1 << (7 * 8)) - 1) { return Unknown; },
+            _ => {},
+        }
+
+        match size.try_into() {
+            Ok(value) => Known(value),
+            Err(_) => Unknown
         }
     }
 }

--- a/src/tag_iterator_util.rs
+++ b/src/tag_iterator_util.rs
@@ -59,6 +59,13 @@ impl<TSpec> ProcessingTag<TSpec> where TSpec: EbmlSpecification<TSpec> + EbmlTag
             NextTag { tag } => tag
         }
     }
+
+    pub fn inner(&self) -> &TSpec {
+        match self {
+            EndTag { tag,.. } => tag,
+            NextTag { tag } => tag
+        }
+    }
 }
 
 pub const DEFAULT_BUFFER_LEN: usize = 1024 * 64;

--- a/src/tag_iterator_util.rs
+++ b/src/tag_iterator_util.rs
@@ -15,11 +15,10 @@ impl From<u64> for EBMLSize {
 }
 
 impl EBMLSize {
-
     pub fn new(size: u64) -> Self {
         const UNKNOWN: u64 = u64::MAX >> 8;
         if size == UNKNOWN {
-            return Unknown
+            Unknown
         } else {
             match size.try_into() {
                 Ok(value) => Known(value),
@@ -27,7 +26,6 @@ impl EBMLSize {
             }
         }
     }
-
 }
 
 pub struct ProcessingTag<TSpec>
@@ -39,11 +37,6 @@ pub struct ProcessingTag<TSpec>
 }
 
 impl<TSpec> ProcessingTag<TSpec> where TSpec: EbmlSpecification<TSpec> + EbmlTag<TSpec> + Clone {
-
-    pub fn get_id(&self) -> u64 {
-        self.tag.get_id()
-    }
-
     pub fn into_inner(self) -> TSpec {
         self.tag
     }

--- a/src/tag_writer.rs
+++ b/src/tag_writer.rs
@@ -61,8 +61,7 @@ impl<W: Write> TagWriter<W>
 
     fn private_flush(&mut self) -> Result<(), TagWriterError> {
         self.dest.write_all(self.working_buffer.drain(..).as_slice()).map_err(|source| TagWriterError::WriteError { source })?;
-        self.dest.flush().map_err(|source| TagWriterError::WriteError { source })?;
-        Ok(())
+        self.dest.flush().map_err(|source| TagWriterError::WriteError { source })
     }
 
     fn write_unsigned_int_tag(&mut self, id: u64, data: &u64) -> Result<(), TagWriterError> {
@@ -212,10 +211,10 @@ impl<W: Write> TagWriter<W>
         }
 
         if self.open_tags.is_empty() {
-            self.private_flush()?;
+            self.private_flush()
+        } else {
+            Ok(())
         }
-
-        Ok(())
     }
 
     ///

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -53,7 +53,7 @@ impl Vint for u16 { }
 impl Vint for u8 { }
 
 fn check_size_u64(val: u64) -> Result<(), ToolError> {
-    if val > (1 << 49) - 2 {
+    if val > (1 << 56) - 1 {
         Err(ToolError::WriteVintOverflow(val))
     } else {
         Ok(())

--- a/tests/derive_spec_compile_with_hierarchy.rs
+++ b/tests/derive_spec_compile_with_hierarchy.rs
@@ -1,0 +1,51 @@
+#[cfg(feature = "derive-spec")]
+pub mod derive_spec_compile {
+    use ebml_iterable::specs::{ebml_specification, TagDataType, Master, EbmlSpecification};
+    
+    #[ebml_specification]
+    #[derive(Clone, Debug, PartialEq)]
+    pub enum Trial {
+        #[id(0x01)]
+        #[data_type(TagDataType::Master)]
+        Root,
+
+        #[id(0x02)]
+        #[data_type(TagDataType::Master)]
+        #[parent(Root)]
+        Parent,
+
+        #[id(0x100)]
+        #[data_type(TagDataType::UnsignedInt)]
+        #[parent(Parent)]
+        Count,
+
+        #[id(0x200)]
+        #[data_type(TagDataType::Binary)]
+        #[parent(Parent)]
+        Data,
+
+        #[id(0x201)]
+        #[data_type(TagDataType::Utf8)]
+        #[parent(Parent)]
+        Name,
+
+        #[id(0x102)]
+        #[data_type(TagDataType::Float)]
+        #[parent(Parent)]
+        Amount,
+
+        #[id(0x101)]
+        #[data_type(TagDataType::Integer)]
+        #[parent(Parent)]
+        Id,  
+    }
+
+    #[test]
+    pub fn compile_worked() {
+        let data_type = Trial::get_tag_data_type(0x01);
+        assert_eq!(TagDataType::Master, data_type);
+        
+        let tag = Trial::get_master_tag(0x01, Master::Start).unwrap();
+        assert_eq!(Trial::Root(Master::Start), tag);
+    }
+}

--- a/tests/test_spec.rs
+++ b/tests/test_spec.rs
@@ -1,0 +1,179 @@
+// use ebml_iterable_specification_derive::easy_ebml;
+// easy_ebml!(
+//     pub enum TestSpec {
+//         Root             : Master = 0x81,
+//         Root/Int         : UnsignedInt = 0x4101,
+//         Root/String      : Utf8 = 0x4102,
+//         Root/Parent      : Master = 0x4103,
+//         Root/Parent/Child: UnsignedInt = 0x210301,
+
+//         Ebml             : Master = 0x1a45dfa3,
+//         Segment          : Master = 0x18538067,
+//         Cluster          : Master = 0x1F43B675,
+//         CueRefCluster    : UnsignedInt = 0x97,
+//         Count            : UnsignedInt = 0x4100,
+//         TrackType        : UnsignedInt = 0x83,
+//         Block            : Binary = 0xa1,
+//         SimpleBlock      : Binary = 0xa3,
+//     }
+// )
+
+use ebml_iterable::specs::TagDataType;
+
+#[derive(Clone, Debug, PartialEq)]
+// Recursive expansion of ebml_specification! macro
+// =================================================
+
+pub enum TestSpec {
+    Root(ebml_iterable::specs::Master<TestSpec>),
+    Int(u64),
+    String(String),
+    Parent(ebml_iterable::specs::Master<TestSpec>),
+    Child(u64),
+    Ebml(ebml_iterable::specs::Master<TestSpec>),
+    Segment(ebml_iterable::specs::Master<TestSpec>),
+    Cluster(ebml_iterable::specs::Master<TestSpec>),
+    CueRefCluster(u64),
+    Count(u64),
+    TrackType(u64),
+    Block(::std::vec::Vec<u8>),
+    SimpleBlock(::std::vec::Vec<u8>),
+    RawTag(u64, ::std::vec::Vec<u8>),
+}
+impl ebml_iterable::specs::EbmlSpecification<TestSpec> for TestSpec {
+    fn get_tag_data_type(id: u64) -> ebml_iterable::specs::TagDataType {
+        match id {
+            129u64 => TagDataType::Master,
+            16641u64 => TagDataType::UnsignedInt,
+            16642u64 => TagDataType::Utf8,
+            16643u64 => TagDataType::Master,
+            2163457u64 => TagDataType::UnsignedInt,
+            440786851u64 => TagDataType::Master,
+            408125543u64 => TagDataType::Master,
+            524531317u64 => TagDataType::Master,
+            151u64 => TagDataType::UnsignedInt,
+            16640u64 => TagDataType::UnsignedInt,
+            131u64 => TagDataType::UnsignedInt,
+            _ => ebml_iterable::specs::TagDataType::Binary,
+        }
+    }
+    fn get_unsigned_int_tag(id: u64, data: u64) -> Option<TestSpec> {
+        match id {
+            16641u64 => Some(TestSpec::Int(data)),
+            2163457u64 => Some(TestSpec::Child(data)),
+            151u64 => Some(TestSpec::CueRefCluster(data)),
+            16640u64 => Some(TestSpec::Count(data)),
+            131u64 => Some(TestSpec::TrackType(data)),
+            _ => None,
+        }
+    }
+    fn get_signed_int_tag(id: u64, _data: i64) -> Option<TestSpec> {
+        match id {
+            _ => None,
+        }
+    }
+    fn get_utf8_tag(id: u64, data: String) -> Option<TestSpec> {
+        match id {
+            16642u64 => Some(TestSpec::String(data)),
+            _ => None,
+        }
+    }
+    fn get_binary_tag(id: u64, data: &[u8]) -> Option<TestSpec> {
+        match id {
+            161u64 => Some(TestSpec::Block(data.to_vec())),
+            163u64 => Some(TestSpec::SimpleBlock(data.to_vec())),
+            _ => None,
+        }
+    }
+    fn get_float_tag(id: u64, _data: f64) -> Option<TestSpec> {
+        match id {
+            _ => None,
+        }
+    }
+    fn get_master_tag(id: u64, data: ebml_iterable::specs::Master<TestSpec>) -> Option<TestSpec> {
+        match id {
+            129u64 => Some(TestSpec::Root(data)),
+            16643u64 => Some(TestSpec::Parent(data)),
+            440786851u64 => Some(TestSpec::Ebml(data)),
+            408125543u64 => Some(TestSpec::Segment(data)),
+            524531317u64 => Some(TestSpec::Cluster(data)),
+            _ => None,
+        }
+    }
+    fn get_raw_tag(id: u64, data: &[u8]) -> TestSpec {
+        TestSpec::RawTag(id, data.to_vec())
+    }
+}
+impl ebml_iterable::specs::EbmlTag<TestSpec> for TestSpec {
+    fn get_id(&self) -> u64 {
+        match self {
+            TestSpec::Root(_) => 129u64,
+            TestSpec::Int(_) => 16641u64,
+            TestSpec::String(_) => 16642u64,
+            TestSpec::Parent(_) => 16643u64,
+            TestSpec::Child(_) => 2163457u64,
+            TestSpec::Ebml(_) => 440786851u64,
+            TestSpec::Segment(_) => 408125543u64,
+            TestSpec::Cluster(_) => 524531317u64,
+            TestSpec::CueRefCluster(_) => 151u64,
+            TestSpec::Count(_) => 16640u64,
+            TestSpec::TrackType(_) => 131u64,
+            TestSpec::Block(_) => 161u64,
+            TestSpec::SimpleBlock(_) => 163u64,
+            TestSpec::RawTag(id, _data) => *id,
+        }
+    }
+    fn get_parent_id(&self) -> Option<u64> {
+        match self {
+            TestSpec::Int(_) => Some(129u64),
+            TestSpec::String(_) => Some(129u64),
+            TestSpec::Parent(_) => Some(129u64),
+            TestSpec::Child(_) => Some(16643u64),
+            _ => None,
+        }
+    }
+    fn as_unsigned_int(&self) -> Option<&u64> {
+        match self {
+            TestSpec::Int(val) => Some(val),
+            TestSpec::Child(val) => Some(val),
+            TestSpec::CueRefCluster(val) => Some(val),
+            TestSpec::Count(val) => Some(val),
+            TestSpec::TrackType(val) => Some(val),
+            _ => None,
+        }
+    }
+    fn as_signed_int(&self) -> Option<&i64> {
+        match self {
+            _ => None,
+        }
+    }
+    fn as_utf8(&self) -> Option<&str> {
+        match self {
+            TestSpec::String(val) => Some(val),
+            _ => None,
+        }
+    }
+    fn as_binary(&self) -> Option<&[u8]> {
+        match self {
+            TestSpec::Block(val) => Some(val),
+            TestSpec::SimpleBlock(val) => Some(val),
+            TestSpec::RawTag(_id, data) => Some(data),
+            _ => None,
+        }
+    }
+    fn as_float(&self) -> Option<&f64> {
+        match self {
+            _ => None,
+        }
+    }
+    fn as_master(&self) -> Option<&ebml_iterable::specs::Master<TestSpec>> {
+        match self {
+            TestSpec::Root(val) => Some(val),
+            TestSpec::Parent(val) => Some(val),
+            TestSpec::Ebml(val) => Some(val),
+            TestSpec::Segment(val) => Some(val),
+            TestSpec::Cluster(val) => Some(val),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
Some updates to the unknown-sized tag feature added by Wicpar.  Main changes have to do with documentation, testing, and adding support for buffering tags of unknown size into memory.